### PR TITLE
Fixing SF4.3+ deprecation notice for `TreeBuilder`

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -2,7 +2,6 @@
 
 namespace Ornicar\AkismetBundle\DependencyInjection;
 
-use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
@@ -17,11 +16,19 @@ class Configuration implements ConfigurationInterface
     /**
      * Generates the configuration tree.
      *
-     * @return NodeInterface
+     * @return TreeBuilder
      */
     public function getConfigTreeBuilder()
     {
-        return (new TreeBuilder())->root('ornicar_akismet', 'array')
+        $treeBuilder = new TreeBuilder('ornicar_akismet');
+        if (\method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            // BC layer for symfony/config 4.1 and older
+            $rootNode = $treeBuilder->root('ornicar_akismet', 'array');
+        }
+
+         $rootNode
             ->children()
                 ->scalarNode('url')->isRequired()->end()
                 ->scalarNode('api_key')->isRequired()->end()
@@ -30,5 +37,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('throw_exceptions')->defaultValue('%kernel.debug%')->end()
             ->end()
         ->end();
+
+        return $treeBuilder;
     }
 }


### PR DESCRIPTION
Fixing Symfony 4.3+ about `Symfony\Component\Config\Definition\Builder\TreeBuilder` deprecation notice, using method `getRootNode()` instead of `root()` method.