### PR TITLE
Guzzle 7 and deps bump

### DIFF
--- a/Akismet/AkismetReal.php
+++ b/Akismet/AkismetReal.php
@@ -76,7 +76,7 @@ class AkismetReal implements AkismetInterface
             }
 
             if ($this->logger) {
-                $this->logger->warn(sprintf('%s: %s(%s)', get_class($this), get_class($e), $e->getMessage()));
+                $this->logger->warning(sprintf('%s: %s(%s)', get_class($this), get_class($e), $e->getMessage()));
             }
 
             return false;
@@ -93,7 +93,7 @@ class AkismetReal implements AkismetInterface
             }
 
             if ($this->logger) {
-                $this->logger->warn(sprintf('%s: %s(%s)', get_class($this), get_class($e), $e->getMessage()));
+                $this->logger->warning(sprintf('%s: %s(%s)', get_class($this), get_class($e), $e->getMessage()));
             }
 
             return false;

--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,9 @@
 
     "require": {
         "php": "^7.0|^8.0",
-        "symfony/framework-bundle": "~2.8|~3.0|~4.0|~5.0",
-        "psr/log": "~1.0",
-        "guzzlehttp/guzzle": "~6.0"
+        "symfony/framework-bundle": "^4.0|^5.0",
+        "psr/log": "^1.0|^2.0|^3.0",
+        "guzzlehttp/guzzle": "^6.0|^7.0"
     },
 
     "autoload": {


### PR DESCRIPTION
```
composer update
Loading composer repositories with package information
Info from https://repo.packagist.org: #StandWithUkraine
Updating dependencies
Lock file operations: 3 installs, 26 updates, 6 removals
  - Removing symfony/debug (v4.4.36)
  - Removing symfony/http-client-contracts (v2.5.0)
  - Removing symfony/polyfill-intl-idn (v1.24.0)
  - Removing symfony/polyfill-intl-normalizer (v1.24.0)
  - Removing symfony/polyfill-php72 (v1.24.0)
  - Removing symfony/polyfill-php73 (v1.24.0)
  - Upgrading guzzlehttp/guzzle (6.5.5 => 7.5.0)
  - Upgrading guzzlehttp/promises (1.5.1 => 1.5.2)
  - Upgrading guzzlehttp/psr7 (1.8.3 => 2.4.3)
  - Upgrading psr/cache (2.0.0 => 3.0.0)
  - Locking psr/event-dispatcher (1.0.0)
  - Locking psr/http-client (1.0.1)
  - Locking psr/http-factory (1.0.1)
  - Upgrading psr/log (1.1.4 => 3.0.0)
  - Upgrading symfony/cache (v5.4.2 => v6.2.0)
  - Upgrading symfony/cache-contracts (v2.5.0 => v3.2.0)
  - Upgrading symfony/config (v5.4.2 => v6.2.0)
  - Upgrading symfony/dependency-injection (v5.4.2 => v6.2.1)
  - Upgrading symfony/deprecation-contracts (v3.0.0 => v3.2.0)
  - Upgrading symfony/error-handler (v4.4.36 => v6.2.1)
  - Upgrading symfony/event-dispatcher (v4.4.34 => v6.2.0)
  - Upgrading symfony/event-dispatcher-contracts (v1.1.11 => v3.2.0)
  - Upgrading symfony/filesystem (v5.4.0 => v6.2.0)
  - Upgrading symfony/finder (v5.4.2 => v6.2.0)
  - Upgrading symfony/framework-bundle (v4.4.36 => v5.4.16)
  - Upgrading symfony/http-foundation (v5.4.2 => v6.2.1)
  - Upgrading symfony/http-kernel (v4.4.36 => v6.2.1)
  - Upgrading symfony/polyfill-ctype (v1.24.0 => v1.27.0)
  - Upgrading symfony/polyfill-mbstring (v1.24.0 => v1.27.0)
  - Upgrading symfony/polyfill-php80 (v1.24.0 => v1.27.0)
  - Upgrading symfony/polyfill-php81 (v1.24.0 => v1.27.0)
  - Upgrading symfony/routing (v5.4.0 => v6.2.0)
  - Upgrading symfony/service-contracts (v2.4.1 => v2.5.2)
  - Upgrading symfony/var-dumper (v5.4.2 => v6.2.1)
  - Upgrading symfony/var-exporter (v6.0.0 => v6.2.1)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 3 installs, 26 updates, 6 removals
  - Downloading symfony/deprecation-contracts (v3.2.0)
  - Downloading psr/http-client (1.0.1)
  - Downloading guzzlehttp/psr7 (2.4.3)
  - Downloading guzzlehttp/promises (1.5.2)
  - Downloading guzzlehttp/guzzle (7.5.0)
  - Downloading symfony/cache-contracts (v3.2.0)
  - Downloading symfony/event-dispatcher-contracts (v3.2.0)
  - Downloading symfony/routing (v6.2.0)
  - Downloading symfony/polyfill-php81 (v1.27.0)
  - Downloading symfony/polyfill-php80 (v1.27.0)
  - Downloading symfony/polyfill-mbstring (v1.27.0)
  - Downloading symfony/polyfill-ctype (v1.27.0)
  - Downloading symfony/http-foundation (v6.2.1)
  - Downloading symfony/event-dispatcher (v6.2.0)
  - Downloading symfony/var-dumper (v6.2.1)
  - Downloading symfony/error-handler (v6.2.1)
  - Downloading symfony/http-kernel (v6.2.1)
  - Downloading symfony/finder (v6.2.0)
  - Downloading symfony/filesystem (v6.2.0)
  - Downloading symfony/var-exporter (v6.2.1)
  - Downloading symfony/service-contracts (v2.5.2)
  - Downloading symfony/dependency-injection (v6.2.1)
  - Downloading symfony/config (v6.2.0)
  - Downloading symfony/cache (v6.2.0)
  - Downloading symfony/framework-bundle (v5.4.16)
  - Removing symfony/polyfill-php73 (v1.24.0)
  - Removing symfony/polyfill-php72 (v1.24.0)
  - Removing symfony/polyfill-intl-normalizer (v1.24.0)
  - Removing symfony/polyfill-intl-idn (v1.24.0)
  - Removing symfony/http-client-contracts (v2.5.0)
  - Removing symfony/debug (v4.4.36)
  - Upgrading symfony/deprecation-contracts (v3.0.0 => v3.2.0): Extracting archive
  - Installing psr/http-client (1.0.1): Extracting archive
  - Installing psr/http-factory (1.0.1): Extracting archive
  - Upgrading guzzlehttp/psr7 (1.8.3 => 2.4.3): Extracting archive
  - Upgrading guzzlehttp/promises (1.5.1 => 1.5.2): Extracting archive
  - Upgrading guzzlehttp/guzzle (6.5.5 => 7.5.0): Extracting archive
  - Upgrading psr/cache (2.0.0 => 3.0.0): Extracting archive
  - Upgrading symfony/cache-contracts (v2.5.0 => v3.2.0): Extracting archive
  - Installing psr/event-dispatcher (1.0.0): Extracting archive
  - Upgrading symfony/event-dispatcher-contracts (v1.1.11 => v3.2.0): Extracting archive
  - Upgrading symfony/routing (v5.4.0 => v6.2.0): Extracting archive
  - Upgrading symfony/polyfill-php81 (v1.24.0 => v1.27.0): Extracting archive
  - Upgrading symfony/polyfill-php80 (v1.24.0 => v1.27.0): Extracting archive
  - Upgrading symfony/polyfill-mbstring (v1.24.0 => v1.27.0): Extracting archive
  - Upgrading symfony/polyfill-ctype (v1.24.0 => v1.27.0): Extracting archive
  - Upgrading symfony/http-foundation (v5.4.2 => v6.2.1): Extracting archive
  - Upgrading symfony/event-dispatcher (v4.4.34 => v6.2.0): Extracting archive
  - Upgrading symfony/var-dumper (v5.4.2 => v6.2.1): Extracting archive
  - Upgrading psr/log (1.1.4 => 3.0.0): Extracting archive
  - Upgrading symfony/error-handler (v4.4.36 => v6.2.1): Extracting archive
  - Upgrading symfony/http-kernel (v4.4.36 => v6.2.1): Extracting archive
  - Upgrading symfony/finder (v5.4.2 => v6.2.0): Extracting archive
  - Upgrading symfony/filesystem (v5.4.0 => v6.2.0): Extracting archive
  - Upgrading symfony/var-exporter (v6.0.0 => v6.2.1): Extracting archive
  - Upgrading symfony/service-contracts (v2.4.1 => v2.5.2): Extracting archive
  - Upgrading symfony/dependency-injection (v5.4.2 => v6.2.1): Extracting archive
  - Upgrading symfony/config (v5.4.2 => v6.2.0): Extracting archive
  - Upgrading symfony/cache (v5.4.2 => v6.2.0): Extracting archive
  - Upgrading symfony/framework-bundle (v4.4.36 => v5.4.16): Extracting archive
Generating autoload files
24 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
```