### PR TITLE
Method "Symfony\Component\DependencyInjection\Extension\ExtensionInte…

### DIFF
--- a/DependencyInjection/OrnicarAkismetExtension.php
+++ b/DependencyInjection/OrnicarAkismetExtension.php
@@ -18,7 +18,7 @@ class OrnicarAkismetExtension extends Extension
     /**
      * Loads and processes configuration to configure the Container.
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $config = (new Processor())->processConfiguration(new Configuration(), $configs);
 


### PR DESCRIPTION
…rface::load()" might add "void" as a native return type declaration in the future. Do the same in implementation "Ornicar\AkismetBundle\DependencyInjection\OrnicarAkismetExtension" now to avoid errors or add an explicit @return annotation to suppress this message